### PR TITLE
Implement catalog sync + filtering for legacy catalog

### DIFF
--- a/.github/workflows/parse_catalog.yaml
+++ b/.github/workflows/parse_catalog.yaml
@@ -3,7 +3,7 @@ name: Parse Catalog
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: "0 */12 * * *"
 
 jobs:
   parse-catalog:
@@ -27,7 +27,7 @@ jobs:
       - name: "Parse catalog"
         shell: bash
         run: |
-          python parse-catalog-from-bq.py
+          python sync_catalogs.py
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
       - name: Save csv file as artifacts

--- a/catalog_utils.py
+++ b/catalog_utils.py
@@ -2,8 +2,8 @@ from bigquery_interface import BQInterface, IIDEntry
 import pandas as pd
 import numpy as np
 import warnings
+from google.cloud import bigquery
 from pangeo_forge_esgf.utils import CMIP6_naming_schema
-
 
 def _maybe_prepend_dummy_dcpp(s: str):
     if not "-" in s:
@@ -55,16 +55,45 @@ def convert_bq_to_cmip6_df(table_id: str) -> pd.DataFrame:
         ]
         return df
 
+def _maybe_join(iterable):
+    assert len(iterable) == 2 
+    dcpp_init_year = iterable[0]
+    member_id = iterable[1]
+    if not pd.isnull(dcpp_init_year):
+        return f"{dcpp_init_year}-{member_id}"
+    else:
+        return member_id
 
-# I need a query to get the latest row for each instance_id
-table_id = "leap-pangeo.testcmip6.cmip6_feedstock_test2"
-table_id_nonqc = "leap-pangeo.testcmip6.cmip6_feedstock_test2_nonqc"
+def convert_cmip6_df_to_iid_df(df: pd.DataFrame) -> pd.DataFrame:
+    # now remove the ones already in the pangeo catalog
 
-df_qc = convert_bq_to_cmip6_df(table_id)
-df_nonqc = convert_bq_to_cmip6_df(table_id_nonqc)
+    df['variant_label'] = df[['dcpp_init_year', 'member_id']].agg(_maybe_join, axis=1)
+    df['version'] = 'v'+df['version'].astype(str)
+    df['instance_id'] = df[['activity_id', 'institution_id', 'source_id', 'experiment_id',
+        'variant_label', 'table_id', 'variable_id', 'grid_label', 'version']].astype(str).agg('.'.join, axis=1).tolist()
+    df['instance_id'] = 'CMIP6.'+df['instance_id']
+    df['store'] = df['zstore']
+    # add current time as bigquery timestamp
+    df['timestamp'] = pd.Timestamp.now(tz='UTC')
+    df = df[['instance_id','store', 'timestamp']]
+    return df
+    
+def upload_cmip6_df_to_bq(df: pd.DataFrame, table_id:str, ):
+    """Upload a pandas dataframe to a bigquery table
+    :param df: pandas dataframe
+    :param table_id: BigQuery table ID
+    **Currently this always overwrites the tabel!**
+    """
+    # should this live in bigquery_interface.py?
+    # TODO: Figure out how to *NOT* overwrite the table and add an `overwrite` kwarg
 
-# write to csv
-if df_qc is not None:
-    df_qc.to_csv("leap-pangeo-cmip6-test.csv", index=False)
-if df_nonqc is not None:
-    df_nonqc.to_csv("leap-pangeo-cmip6-noqc-test.csv", index=False)
+    # From https://stackoverflow.com/a/57226898
+    client = bigquery.Client()
+
+    job_config = bigquery.job.LoadJobConfig()
+    job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
+
+    client.load_table_from_dataframe(df, table_id, job_config=job_config).result()
+
+
+

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -2479,6 +2479,9 @@ iids_sub_issue_41 = [
 
 iids = iids_sub_issue_41 + iids_sub_issue_20 + iids_sub_tim + iids_sub_issue_22 + iids_PMIP_vel
 
+# just for testing the PR add an iid that is definitely in the legacy table
+iids = ['CMIP6.HighResMIP.CMCC.CMCC-CM2-HR4.highresSST-present.r1i1p1f1.Amon.ps.gn.v20170706']
+
 prune_iids = False
 prune_submission = False # if set, only submits a subset of the iids in the final step
 
@@ -2489,23 +2492,27 @@ iids = list(set(iids))
 print("Pruning iids that already exist")
 table_id = 'leap-pangeo.testcmip6.cmip6_feedstock_test2'
 table_id_nonqc = 'leap-pangeo.testcmip6.cmip6_feedstock_test2_nonqc'
+table_id_legacy = "leap-pangeo.testcmip6.cmip6_legacy"
 # TODO: To create a non-QC catalog I need to find the difference between the two tables iids
 
 bq_interface = BQInterface(table_id=table_id)
 bq_interface_nonqc = BQInterface(table_id=table_id_nonqc)
+bq_interface_legacy = BQInterface(table_id=table_id_legacy)
 
 # get lists of the iids already logged
 iids_in_table = bq_interface.iid_list_exists(iids)
 iids_in_table_nonqc = bq_interface_nonqc.iid_list_exists(iids)
+iids_in_table_legacy = bq_interface_legacy.iid_list_exists(iids)
 
 # beam does NOT like to pickle client objects (https://github.com/googleapis/google-cloud-python/issues/3191#issuecomment-289151187)
 del bq_interface 
 del bq_interface_nonqc
+del bq_interface_legacy
 
 # Maybe I want a more finegrained check here at some point, but for now this will prevent logged iids from rerunning
-iids_to_skip = set(iids_in_table + iids_in_table_nonqc)
+iids_to_skip = set(iids_in_table + iids_in_table_nonqc + iids_in_table_legacy)
 iids_filtered = list(set(iids) - iids_to_skip)
-print(f"Pruned {len(iids) - len(iids_filtered)} iids from input list")
+print(f"Pruned {len(iids) - len(iids_filtered)}/{len(iids)} iids from input list")
 print(f"Running a total of {len(iids_filtered)} iids")
 
 if prune_iids:

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -2479,9 +2479,6 @@ iids_sub_issue_41 = [
 
 iids = iids_sub_issue_41 + iids_sub_issue_20 + iids_sub_tim + iids_sub_issue_22 + iids_PMIP_vel
 
-# just for testing the PR add an iid that is definitely in the legacy table
-iids = ['CMIP6.HighResMIP.CMCC.CMCC-CM2-HR4.highresSST-present.r1i1p1f1.Amon.ps.gn.v20170706']
-
 prune_iids = False
 prune_submission = False # if set, only submits a subset of the iids in the final step
 

--- a/sync_catalogs.py
+++ b/sync_catalogs.py
@@ -1,0 +1,25 @@
+
+from catalog_utils import convert_bq_to_cmip6_df, convert_cmip6_df_to_iid_df, upload_cmip6_df_to_bq
+import pandas as pd
+
+
+# I need a query to get the latest row for each instance_id
+#TODO: these need to be centrally defined
+table_id_legacy = "leap-pangeo.testcmip6.cmip6_legacy"
+table_id = "leap-pangeo.testcmip6.cmip6_feedstock_test2"
+table_id_nonqc = "leap-pangeo.testcmip6.cmip6_feedstock_test2_nonqc"
+
+# write out csv from bq
+df_qc = convert_bq_to_cmip6_df(table_id)
+df_nonqc = convert_bq_to_cmip6_df(table_id_nonqc)
+
+# write to csv
+if df_qc is not None:
+    df_qc.to_csv("leap-pangeo-cmip6-test.csv", index=False)
+if df_nonqc is not None:
+    df_nonqc.to_csv("leap-pangeo-cmip6-noqc-test.csv", index=False)
+
+# write bq from legacy csv (??? Should we do this in a separate script?)
+df_legacy = pd.read_csv('https://storage.googleapis.com/cmip6/pangeo-cmip6.csv')
+
+upload_cmip6_df_to_bq(convert_cmip6_df_to_iid_df(df_legacy), table_id_legacy)


### PR DESCRIPTION
- [ ] Closes #43

- This implements a sync (overwriting each time to accomodate for future retractions/removals) of the legacy catalog to another BQ table in the same format as our existing tables [here](https://github.com/leap-stc/cmip6-leap-feedstock/blob/filter-existing-catalog/sync_catalogs.py). For now this is combined with the BQ to csv conversion in the gh action. [`Parse Catalog`](https://github.com/leap-stc/cmip6-leap-feedstock/actions/workflows/parse_catalog.yaml) workflow will now basically handle all of our cataloging needs
- Adds another filtering step in the recipe to avoid running iids that are already in the main catalog
