### PR TITLE
Update pangeo-forge-big-query naming

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -5,7 +5,7 @@ import apache_beam as beam
 from dataclasses import dataclass
 from typing import List, Dict
 from pangeo_forge_esgf import get_urls_from_esgf, setup_logging
-from data_managment_utils.utils import BQInterface, LogToBigQuery
+from data_management_utils import BQInterface, LogToBigQuery
 from pangeo_forge_esgf.parsing import parse_instance_ids
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -5,7 +5,7 @@ import apache_beam as beam
 from dataclasses import dataclass
 from typing import List, Dict
 from pangeo_forge_esgf import get_urls_from_esgf, setup_logging
-from pangeo_forge_big_query.utils import BQInterface, LogToBigQuery
+from data_managment_utils.utils import BQInterface, LogToBigQuery
 from pangeo_forge_esgf.parsing import parse_instance_ids
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/carbonplan/pangeo-forge-big-query
+git+https://github.com/leap-stc/data-management-utils
 pangeo-forge-esgf==0.1.1
 pangeo-forge-recipes==0.10.4
 dynamic-chunks==0.0.2


### PR DESCRIPTION
This PR updates this feedstock to fix the changes in import names. `pangeo-forge-big-query` is not `data-management-utils`.
https://github.com/leap-stc/data-management-utils/tree/main