### PR TITLE
Refactor csv creation from single bigquery table

### DIFF
--- a/.github/workflows/parse_catalog.yaml
+++ b/.github/workflows/parse_catalog.yaml
@@ -22,12 +22,12 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        #FIXME: PGF-esgf needs install from pr for now.
-        run: python -m pip install pandas pangeo-forge-esgf google-cloud-bigquery db-dtypes git+https://github.com/jbusecke/pangeo-forge-esgf.git@beam-refactor
+        # TODO: base on an actual release
+        run: python -m pip install git+https://github.com/leap-stc/leap-data-management-utils.git@factor-out-cmip
       - name: "Parse catalog"
         shell: bash
         run: |
-          python sync_catalogs.py
+          python scripts/dump_bigquery_to_csv.py
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
       - name: Save csv file as artifacts
@@ -35,32 +35,3 @@ jobs:
         with:
           name: csv-files
           path: "*.csv"
-  write-to-gcs:
-    name: write-csv-to-gcs
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    needs: [parse-catalog]
-    steps:
-      - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: csv-files
-      - name: Authenticate to Google Cloud
-        id: "auth"
-        uses: google-github-actions/auth@v1
-        with:
-          # credentials_json: "${{ secrets.GCP_PUBLIC_CMIP6_SERVICE_ACCOUNT }}"
-          credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
-      - name: Set up Cloud SDK and upload csv files
-        uses: google-github-actions/setup-gcloud@v1
-      - name: Upload csv files to GCS
-        run: |
-          gcloud storage cp *.csv gs://cmip6/cmip6-pgf-ingestion-test/catalogs/
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
-      # - name: Set csv file object to public
-      #   run: |
-      #     gcloud storage objects update gs://leap-persistent-ro/data-library/catalogs/cmip6-test/leap-pangeo-cmip6-noqc-test.csv gs://leap-persistent-ro/data-library/catalogs/cmip6-test/leap-pangeo-cmip6-test.csv --add-acl-grant=entity=AllUsers,role=READER
-      #   env:
-      #     GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"

--- a/scripts/dump_bigquery_to_csv.py
+++ b/scripts/dump_bigquery_to_csv.py
@@ -1,0 +1,43 @@
+from leap_data_management_utils import CMIPBQInterface
+from leap_data_management_utils.cmip_catalog import bq_df_to_intake_esm
+import pandas as pd
+import os
+import gcsfs
+from datetime import date
+
+table_id = 'leap-pangeo.testcmip6.cmip6_consolidated_manual_testing'
+target_prefix = "gs://cmip6/cmip6-pgf-ingestion-test/catalog/"
+
+bq = CMIPBQInterface(table_id=table_id)
+
+df_all = bq.get_latest()
+
+df_retracted = df_all[df_all['retracted'] == True]
+df_all_wo_retracted = df_all[df_all['retracted'] == False]
+
+df_qc_failed = df_all_wo_retracted[df_all_wo_retracted['tests_passed'] == False]
+df_qc = df_all_wo_retracted[df_all_wo_retracted['tests_passed'] == True]
+
+fs = gcsfs.GCSFileSystem()
+
+for filename, bq_df in [
+    ("qc", df_qc),
+    ("qc_failed", df_qc_failed),
+    ("retracted", df_retracted),
+]:
+    path = os.path.join(
+        target_prefix, 
+        f"pangeo_esgf_zarr_{filename}.csv"
+    )
+    path_backup = os.path.join(
+        target_prefix, 
+        'backups',
+        f"pangeo_esgf_zarr_{filename}_backup_{date.today()}.csv"
+    )
+    
+    if len(bq_df)> 0:
+        intake_esm_df = bq_df_to_intake_esm(bq_df)
+        intake_esm_df.to_csv(filename)
+        if fs.exists(path):
+            fs.cp(path, path_backup)
+        fs.put_file(filename, path)


### PR DESCRIPTION
This is part of a larger effort to consolidate all CMIP ingestion to a single bigquery table.

This script loads the most recent data for all iids and parses it out into three categories:

- retracted
- not retracted, but failed the quality control
- not retracted, quality controlled

 