### PR TITLE
Add retraction workflow + script

### DIFF
--- a/.github/workflows/retraction.yaml
+++ b/.github/workflows/retraction.yaml
@@ -1,0 +1,36 @@
+name: Flag Retractions
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  remove-retractions:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Authenticate to Google Cloud"
+        id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        # TODO: base on an actual release
+        run: python -m pip install tqdm httpx gcsfs git+https://github.com/leap-stc/leap-data-management-utils.git@factor-out-cmip
+      - name: "Parse catalog"
+        shell: bash
+        run: |
+          python scripts/retraction.py
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ steps.auth.outputs.credentials_file_path }}"
+      - name: Upload-retraction-report
+        uses: actions/upload-artifact@v3
+        with:
+          name: retraction-report
+          path: "retraction-report.html"

--- a/scripts/retraction.py
+++ b/scripts/retraction.py
@@ -1,0 +1,80 @@
+import asyncio
+import httpx
+from tqdm.asyncio import tqdm
+from leap_data_management_utils.cmip_utils import IIDEntry, CMIPBQInterface
+
+# there is an annoying bug that will make this fail when the number of tasks gathered exceeds `max_connections`
+# https://github.com/encode/httpx/issues/1171
+
+# Suggested workaround: https://github.com/encode/httpx/issues/1171#issuecomment-791614435
+
+max_connections = 5
+semaphore = asyncio.Semaphore(max_connections)
+limits = httpx.Limits(max_connections=3, max_keepalive_connections=1)
+
+async def fetch_batch_instance_ids(client: httpx.AsyncClient, url:str, params: dict, offset:int, batchsize:int) -> list[str]:
+    async with semaphore: 
+        response = await client.get(url, params=params|{'offset':offset, 'limit':batchsize})
+        return [ d['instance_id'] for d in response.json()['response']['docs']]
+
+async def fetch_instance_ids(url, params):
+    async with httpx.AsyncClient(limits=limits, timeout=30.0) as client:
+        # Initial response
+        init_response = await client.get(url, params=params|{'offset':0, 'limit':1})
+        n_res = init_response.json()['response']['numFound']
+        # n_res = 4000 # for testing
+        
+        # fetch batches
+        batchsize = 10000
+        tasks = [
+            asyncio.ensure_future(
+                fetch_batch_instance_ids(
+                    client,
+                    url,
+                    params,
+                    i,
+                    batchsize
+                )
+            ) for i in range(0,n_res, batchsize)
+        ]
+        
+        retracted = await tqdm.gather(*tasks)
+
+        retracted_flat = []
+        for l in retracted:
+            retracted_flat.extend(l)
+        return retracted_flat
+    
+retracted_iids = await fetch_instance_ids(url, params)
+
+table_id = 'leap-pangeo.testcmip6.cmip6_consolidated_manual_testing' #TODO: change to production table
+bq = CMIPBQInterface(table_id)
+
+# Get all the latest entries
+df_all = bq.get_latest()
+
+# Find all entries that match ESGF retractions
+df_retracted = df_all[df_all['instance_id'].isin(retracted_iids)]
+
+# Find all the entries that are not marked as retracted yet
+to_retract = df_retracted[df_retracted['retracted'].isin([False])]
+
+# Print statistics and create report html
+print(
+    f"Got {len(retracted_iids)} retractions from ESGF.\n"
+    f"{len(df_retracted)} of our stores are affected.\n"
+    f"{len(to_retract)} stores will be newly marked as retracted.\n"
+    f"See retraction_report.html for details"
+)
+to_retract.to_html('retraction_report.html')
+
+## Create IIDEntry objects for all the entries that need to be retracted
+iid_entries_to_retract = []
+for idx, row in to_retract.iloc[:3,:].iterrows(): #TODO: remove the [:3,:] for production
+    iid_entry = IIDEntry(iid=row.instance_id, store=row.store, retracted=True, tests_passed=row.tests_passed)
+    iid_entries_to_retract.append(iid_entry)
+
+# set values to retract in batches
+batchsize = 1000 # not sure what the max no of entries is that bq can handle at once
+for batch_iid_entries in [iid_entries_to_retract[i:i+batchsize] for i in range(0,len(iid_entries_to_retract), batchsize)]:
+    bq.insert_multiple_iids(batch_iid_entries)


### PR DESCRIPTION
This introduces a vastly more efficient python script to:
- Download ALL retracted datasets from the ESGF API (async FTW)
- Flag datasets as retracted in the consolidated bq table
- Generate a report of newly flagged datasets.