### PR TITLE
Bump pgf-recipes to includ multidim rechunk fix

### DIFF
--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/leap-stc/leap-data-management-utils@factor-out-cmip
 pangeo-forge-esgf==0.1.1
-pangeo-forge-recipes==0.10.5
+pangeo-forge-recipes==0.10.6
 dynamic-chunks==0.0.2
 gcsfs
 apache-beam[gcp]


### PR DESCRIPTION
In #110 I changed the requirements from the PR branch to 0.10.5, but I believe that did not actually include https://github.com/pangeo-forge/pangeo-forge-recipes/pull/708. From the [release notes](https://github.com/pangeo-forge/pangeo-forge-recipes/releases/tag/0.10.6) it seems the correct version to pin would be 0.10.6

Just tagging @cisaacstern to confirm this.