### PR TITLE
Sharpen zombie killer again

### DIFF
--- a/.github/workflows/ash.yaml
+++ b/.github/workflows/ash.yaml
@@ -19,7 +19,7 @@ jobs:
           credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
       - name: Set up Cloud SDK and upload csv files
         uses: google-github-actions/setup-gcloud@v2
-      - name: Kill all active jobs older than 24 hours
+      - name: Kill all active jobs older than 6 hours
         shell: python -u {0}
         run: |
           import subprocess
@@ -27,7 +27,7 @@ jobs:
 
           jobs = json.loads(subprocess.check_output([
             "gcloud", "dataflow", "jobs", "list",
-            "--created-before=-p24h", "--status=active",
+            "--created-before=-p6h", "--status=active",
             "--filter=name:a618127503*", "--format=json",
             "--region=us-central1"
           ]))


### PR DESCRIPTION
I am not sure any of these jobs should take longer than a few hours to complete. The ones that take longer might be hanging forever with the fsspec.open() call (perhaps related to https://github.com/pangeo-forge/pangeo-forge-recipes/issues/710?). The only proper reason I could think of why a job should take multiple hours is the caching of input data. In that case we might want to trigger the deploy action manually?
