### PR TITLE
Don't deploy for unrelated code changes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,9 +4,19 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+    paths: # only run on changes to feedstock relevant code
+      - 'feedstock/**'
+      - 'configs/**'
+      - '.github/workflows/deploy.yaml'
   pull_request:
     branches: ["main"]
     types: [opened, reopened, synchronize, labeled]
+    paths: # only run on changes to feedstock relevant code
+      - 'feedstock/**'
+      - 'configs/**'
+      - '.github/workflows/deploy.yaml'
+
+    
   # schedule:
   #   - cron: "0 * * * SUN" # run every sunday
 


### PR DESCRIPTION
This PR implements a paths filter for the deploy workflow, so this does not always get triggered when I make changes to e.g. the README.