### PR TITLE
Fix retraction script

### DIFF
--- a/.github/workflows/retraction.yaml
+++ b/.github/workflows/retraction.yaml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.9"
       - name: Install dependencies
         # TODO: base on an actual release
-        run: python -m pip install tqdm httpx gcsfs git+https://github.com/leap-stc/leap-data-management-utils.git@factor-out-cmip
+        run: python -m pip install tqdm httpx gcsfs leap-data-management-utils==0.0.5
       - name: "Run retraction script"
         shell: bash
         run: |


### PR DESCRIPTION
I just noticed that our retraction logic was [broken](https://github.com/leap-stc/cmip6-leap-feedstock/actions/runs/8768744324) due to an import error from https://github.com/leap-stc/leap-data-management-utils. This is likely related to the refactor [here](https://github.com/leap-stc/leap-data-management-utils/pull/9)