### PR TITLE
Factor out all custom stages

### DIFF
--- a/feedstock/iids_pr.yaml
+++ b/feedstock/iids_pr.yaml
@@ -1,1 +1,1 @@
-    - "CMIP6.*.*.*.historical.*.Omon.[tos, so].*.*"
+    - "CMIP6.*.*.[CNRM-CM6-1,CanESM5,MIROC6].historical.*.Omon.[tos, so].*.*"

--- a/feedstock/iids_pr.yaml
+++ b/feedstock/iids_pr.yaml
@@ -1,1 +1,1 @@
-    - "CMIP6.*.*.[CNRM-CM6-1,CanESM5,MIROC6].historical.*.Omon.[tos, so].*.*"
+    - "CMIP6.*.*.[CNRM-CM6-1,CanESM5].historical.*.Omon.[tos, so].*.*"

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -33,7 +33,7 @@ print(f"{is_test =}")
 
 if is_test:
     setup_logging("DEBUG")
-    copy_target_bucket = "gs://leap-scratch/data-library/cmip6-pr-copied/"
+    copy_target_prefix = "gs://leap-scratch/data-library/cmip6-pr-copied/"
     iid_file = "feedstock/iids_pr.yaml"
     prune_iids = True
     prune_submission = (
@@ -54,7 +54,7 @@ if is_test:
 
 else:
     setup_logging("INFO")
-    copy_target_bucket = "gs://cmip6/cmip6-pgf-ingestion-test/zarr_stores/"
+    copy_target_prefix = "gs://cmip6/cmip6-pgf-ingestion-test/zarr_stores/"
     iid_file = "feedstock/iids.yaml"
     prune_iids = False
     prune_submission = (
@@ -65,7 +65,7 @@ else:
     print(f"{table_id = } {prune_submission = } {iid_file = }")
 
 print("Running with the following parameters:")
-print(f"{copy_target_bucket = }")
+print(f"{copy_target_prefix = }")
 print(f"{iid_file = }")
 print(f"{prune_iids = }")
 print(f"{prune_submission = }")
@@ -245,7 +245,7 @@ for iid, urls in url_dict.items():
         | InjectAttrs()
         | ConsolidateDimensionCoordinates()
         | ConsolidateMetadata()
-        | Copy(target_prefix=copy_target_bucket)
+        | Copy(target=copy_target_prefix)
         | "Logging to bigquery (non-QC)"
         >> LogCMIPToBigQuery(iid=iid, table_id=table_id, tests_passed=False)
         | TestDataset(iid=iid)

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -2,22 +2,18 @@
 """Modified transforms from Pangeo Forge"""
 
 import apache_beam as beam
-from dataclasses import dataclass
 from typing import List, Dict
 from dask.utils import parse_bytes
 from pangeo_forge_esgf import get_urls_from_esgf, setup_logging
 from leap_data_management_utils import CMIPBQInterface, LogCMIPToBigQuery
 from leap_data_management_utils.data_management_transforms import Copy, InjectAttrs
 from leap_data_management_utils.cmip_transforms import Preprocessor, TestDataset
-from leap_data_management_utils.cmip_testing import test_all
 from pangeo_forge_esgf.parsing import parse_instance_ids
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (
     OpenURLWithFSSpec,
     OpenWithXarray,
     StoreToZarr,
-    Indexed,
-    T,
     ConsolidateMetadata,
     ConsolidateDimensionCoordinates,
 )
@@ -26,7 +22,6 @@ import logging
 import os
 import xarray as xr
 import yaml
-import zarr
 
 logger = logging.getLogger(__name__)
 

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -229,7 +229,6 @@ def dynamic_chunking_func(ds: xr.Dataset) -> Dict[str, int]:
 recipes = {}
 
 for iid, urls in url_dict.items():
-    print(f"{copy_target_bucket = }")
     pattern = pattern_from_file_sequence(urls, concat_dim="time")
     recipes[iid] = (
         f"Creating {iid}" >> beam.Create(pattern.items())

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -237,7 +237,7 @@ for iid, urls in url_dict.items():
         | OpenWithXarray(xarray_open_kwargs={"use_cftime": True})
         | Preprocessor()
         | StoreToZarr(
-            store_name=,
+            store_name=f"{iid}.zarr",
             combine_dims=pattern.combine_dim_keys,
             dynamic_chunking_fn=dynamic_chunking_func,
         )

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -247,7 +247,11 @@ for iid, urls in url_dict.items():
         | InjectAttrs()
         | ConsolidateDimensionCoordinates()
         | ConsolidateMetadata()
-        | Copy(target=os.path.join(copy_target_prefix, f"{run_id}_{run_attempt}", f"{iid}.zarr"))
+        | Copy(
+            target=os.path.join(
+                copy_target_prefix, f"{run_id}_{run_attempt}", f"{iid}.zarr"
+            )
+        )
         | "Logging to bigquery (non-QC)"
         >> LogCMIPToBigQuery(iid=iid, table_id=table_id, tests_passed=False)
         | TestDataset(iid=iid)

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -31,6 +31,9 @@ is_test = (
 )  # There must be a better way to do this, but for now this will do
 print(f"{is_test =}")
 
+run_id = os.environ["GITHUB_RUN_ID"]
+run_attempt = os.environ["GITHUB_RUN_ATTEMPT"]
+
 if is_test:
     setup_logging("DEBUG")
     copy_target_prefix = "gs://leap-scratch/data-library/cmip6-pr-copied/"
@@ -244,7 +247,7 @@ for iid, urls in url_dict.items():
         | InjectAttrs()
         | ConsolidateDimensionCoordinates()
         | ConsolidateMetadata()
-        | Copy(target=os.path.join(copy_target_prefix, f"{iid}.zarr"))
+        | Copy(target=os.path.join(copy_target_prefix, f"{run_id}_{run_attempt}", f"{iid}.zarr"))
         | "Logging to bigquery (non-QC)"
         >> LogCMIPToBigQuery(iid=iid, table_id=table_id, tests_passed=False)
         | TestDataset(iid=iid)

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -237,14 +237,14 @@ for iid, urls in url_dict.items():
         | OpenWithXarray(xarray_open_kwargs={"use_cftime": True})
         | Preprocessor()
         | StoreToZarr(
-            store_name=f"{iid}.zarr",
+            store_name=,
             combine_dims=pattern.combine_dim_keys,
             dynamic_chunking_fn=dynamic_chunking_func,
         )
         | InjectAttrs()
         | ConsolidateDimensionCoordinates()
         | ConsolidateMetadata()
-        | Copy(target=copy_target_prefix)
+        | Copy(target=os.path.join(copy_target_prefix, f"{iid}.zarr"))
         | "Logging to bigquery (non-QC)"
         >> LogCMIPToBigQuery(iid=iid, table_id=table_id, tests_passed=False)
         | TestDataset(iid=iid)

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -7,7 +7,7 @@ from dask.utils import parse_bytes
 from pangeo_forge_esgf import get_urls_from_esgf, setup_logging
 from leap_data_management_utils import CMIPBQInterface, LogCMIPToBigQuery
 from leap_data_management_utils.data_management_transforms import Copy, InjectAttrs
-from leap_data_management_utils.cmip_transforms import Preprocessor, TestDataset
+from leap_data_management_utils.cmip_transforms import TestDataset, Preprocessor
 from pangeo_forge_esgf.parsing import parse_instance_ids
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,4 +1,4 @@
-leap-data-management-utils==0.0.2
+leap-data-management-utils==0.0.5
 pangeo-forge-esgf==0.2.0
 dynamic-chunks==0.0.3
 git+https://github.com/ranchodeluxe/xarray@ranchodeluxe-patch-1#egg=xarray

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,5 +1,4 @@
-#leap-data-management-utils==0.0.6
-git+https://github.com/leap-stc/leap-data-management-utils.git@improved-attrs-inject
+leap-data-management-utils==0.0.7
 pangeo-forge-esgf==0.2.0
 dynamic-chunks==0.0.3
 git+https://github.com/ranchodeluxe/xarray@ranchodeluxe-patch-1#egg=xarray

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,4 +1,4 @@
-leap-data-management-utils==0.0.5
+leap-data-management-utils==0.0.6
 pangeo-forge-esgf==0.2.0
 dynamic-chunks==0.0.3
 git+https://github.com/ranchodeluxe/xarray@ranchodeluxe-patch-1#egg=xarray

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,4 +1,5 @@
-leap-data-management-utils==0.0.6
+#leap-data-management-utils==0.0.6
+git+https://github.com/leap-stc/leap-data-management-utils.git@improved-attrs-inject
 pangeo-forge-esgf==0.2.0
 dynamic-chunks==0.0.3
 git+https://github.com/ranchodeluxe/xarray@ranchodeluxe-patch-1#egg=xarray


### PR DESCRIPTION
- [x] Closes #132 
- Adds pangeo-forge specific attrs (time of recipe build, git hashe used to build) see [here](https://github.com/leap-stc/leap-data-management-utils/blob/f599f6f1862ace5c2090c5d53654d071567c6da9/leap_data_management_utils/data_management_transforms.py#L202-L203)
    - [x] the time is properly injected, but the git hash is not!  
- [x] Check on the leap-scratch output to confirm all the attrs are properly injected
- [x] Change requirements to released version of leap-data-management-tools
- [x] Open an issue to discuss if we should overwrite in place (as we do here!). Maybe we want to retain our gh action based folder structure so that users are not suddenly experiencing issues when data is overwritten.