### PR TITLE
Testing the new async client

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Set up a local dev environment
 mamba create -n cmip6-feedstock python=3.11 -y
 conda activate cmip6-feedstock
 pip install pangeo-forge-runner==0.10.2 --no-cache-dir
-pip intall -r feedstock/requirements.txt
+pip install -r feedstock/requirements.txt
 ```
 
 #### Debug recipe locally

--- a/feedstock/iids.yaml
+++ b/feedstock/iids.yaml
@@ -13,7 +13,7 @@
 #     - 'CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.uo.gr1.v20200911'
 #     - 'CMIP6.PMIP.MPI-M.MPI-ESM1-2-LR.lgm.r1i1p1f1.Omon.uo.gn.v20200909'
 #     - 'CMIP6.PMIP.AWI.AWI-ESM-1-1-LR.lgm.r1i1p1f1.Omon.vo.gn.v20200212'
-#     - 'CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.vo.gn.v20191002'
+    - 'CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.vo.gn.v20191002'
 #     - 'CMIP6.PMIP.AWI.AWI-ESM-1-1-LR.lgm.r1i1p1f1.Odec.vo.gn.v20200212'
 #     - 'CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.vo.gr1.v20200911'
 #     - 'CMIP6.PMIP.MPI-M.MPI-ESM1-2-LR.lgm.r1i1p1f1.Omon.vo.gn.v20190710'

--- a/feedstock/iids_pr.yaml
+++ b/feedstock/iids_pr.yaml
@@ -1,1 +1,1 @@
-   - "CMIP6.*.*.[CNRM-CM6-1,CanESM5].historical.*.Omon.[tos, so].*.*"
+   - "CMIP6.*.*.[CNRM-CM6-1,CanESM5].historical.*.Omon.[tos, so, o2].*.*"

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -138,9 +138,9 @@ recipe_data = asyncio.run(get_recipe_inputs())
 logger.info(f"Got urls for iids: {list(recipe_data.keys())}")
 
 if prune_submission:
-    recipe_dict = {i: recipe_data[i] for i in list(recipe_data.keys())[0:5]}
+    recipe_data = {i: recipe_data[i] for i in list(recipe_data.keys())[0:5]}
 
-logger.info(f"🚀 Submitting a total of {len(recipe_dict)} iids")
+logger.info(f"🚀 Submitting a total of {len(recipe_data)} iids")
 
 # Print the actual data
 logger.debug(f"{recipe_data=}")

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -9,9 +9,12 @@ from leap_data_management_utils.cmip_transforms import (
     Preprocessor,
     dynamic_chunking_func,
     CMIPBQInterface,
-    LogCMIPToBigQuery
+    LogCMIPToBigQuery,
 )
-from pangeo_forge_esgf.async_client import ESGFAsyncClient,get_sorted_http_urls_from_iid_dict
+from pangeo_forge_esgf.async_client import (
+    ESGFAsyncClient,
+    get_sorted_http_urls_from_iid_dict,
+)
 from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.transforms import (
     OpenURLWithFSSpec,
@@ -24,7 +27,6 @@ import logging
 import asyncio
 import os
 import yaml
-from tqdm.auto import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -85,10 +87,12 @@ with open(iid_file) as f:
 # parse out wildcard/square brackets using pangeo-forge-esgf
 logger.debug(f"{iids_raw = }")
 
+
 async def parse_iids():
     async with ESGFAsyncClient() as client:
         return await client.expand_iids(iids_raw)
-    
+
+
 iids = asyncio.run(parse_iids())
 logger.info(f"Submitted {iids = }")
 
@@ -123,9 +127,13 @@ if prune_iids:
     iids_filtered = iids_filtered[0:20]
 
 print(f"🚀 Requesting a total of {len(iids_filtered)} datasets")
+
+
 async def get_recipe_inputs():
     async with ESGFAsyncClient() as client:
         return await client.recipe_data(iids_filtered)
+
+
 recipe_data = asyncio.run(get_recipe_inputs())
 logger.info(f"Got urls for iids: {list(recipe_data.keys())}")
 

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -107,10 +107,10 @@ iids_in_table = bq_interface.iid_list_exists(iids)
 
 # manual overrides (these will be rewritten each time as long as they exist here)
 overwrite_iids = [
-    # "CMIP6.HighResMIP.MOHC.HadGEM3-GC31-HH.highres-future.r1i1p1f1.Omon.thetao.gn.v20200514",
-    # "CMIP6.HighResMIP.NERC.HadGEM3-GC31-HH.hist-1950.r1i1p1f1.Omon.thetao.gn.v20200514",
-    # "CMIP6.HighResMIP.MOHC.HadGEM3-GC31-HH.highres-future.r1i1p1f1.Omon.so.gn.v20200514",
-    # "CMIP6.HighResMIP.NERC.HadGEM3-GC31-HH.hist-1950.r1i1p1f1.Omon.so.gn.v20200514",
+    "CMIP6.HighResMIP.MOHC.HadGEM3-GC31-HH.highres-future.r1i1p1f1.Omon.thetao.gn.v20200514",
+    "CMIP6.HighResMIP.NERC.HadGEM3-GC31-HH.hist-1950.r1i1p1f1.Omon.thetao.gn.v20200514",
+    "CMIP6.HighResMIP.MOHC.HadGEM3-GC31-HH.highres-future.r1i1p1f1.Omon.so.gn.v20200514",
+    "CMIP6.HighResMIP.NERC.HadGEM3-GC31-HH.hist-1950.r1i1p1f1.Omon.so.gn.v20200514",
 ]
 
 # beam does NOT like to pickle client objects (https://github.com/googleapis/google-cloud-python/issues/3191#issuecomment-289151187)


### PR DESCRIPTION
I actually f'ed up before and pushed to main. I cancelled the action and am just adding this PR so I can convince myself that things run smoothly in the end-to-end scenario.

Overall the new [async client](https://github.com/jbusecke/pangeo-forge-esgf/pull/45) seems to work well and fast! We are now searching/combining results from multiple index nodes. Check across data nodes and dataset metadata that we have all files (to avoid #53 in the future), and we have all the metadata in the world to retest datasets afterwards. 

As far as I am concerned, if we cannot fix an issue with the entire API response and the data, it is out of our responsibility.

Those changes will address the following issues:
- Part ways toward #133 
- [x] Closes  #32 (see also https://github.com/leap-stc/cmip6-leap-feedstock/issues/133#issuecomment-2105532412)
- [x] Closes out #11 (even though that was mostly addressed by adding the `AttributeInjection` Stage earlier) 